### PR TITLE
L4D common infected

### DIFF
--- a/Decorate/MonL4D.txt
+++ b/Decorate/MonL4D.txt
@@ -279,21 +279,6 @@ Actor L4DTankRockTrown
 //======================================================================================
 //======================================================================================
 
-Actor L4DCommonIceDeathSoundPlayer
-{
-	+NOINTERACTION
-	Renderstyle None
-	States
-	{
-	Spawn:
-		TNT1 A 0 NoDelay A_Jump(192,"Death")
-		TNT1 A random(15,70) A_PlaySound("misc/icebreak")
-	Death:
-		TNT1 A 0
-		Stop
-	}
-}
-
 Actor L4DCommonHP : HealthBonus
 {
 	Inventory.MaxAmount 30
@@ -442,10 +427,7 @@ Actor L4DCommonMale1
 		"####" "#" 0 A_GenericFreezeDeath 
 		"####" "#" 0 A_GiveInventory("L4DCommonScore",1,AAPTR_PLAYER1)
 		//"####" "#" 1 A_FreezeDeathChunks // [Ms] Makes 28 shards -- blasphemously many!
-	StillIce:
-		"####" "#" random(35,69)
-		"####" "#" 0 A_JumpIf(abs(velx)+abs(vely) > 3, "StillIce")
-		"####" "#" 0 A_SpawnItemEx("L4DCommonIceDeathSoundPlayer",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION)
+		"####" "#" 0 A_PlaySound("misc/icebreak")
 		"####" "#####" 0 A_SpawnItemEx("AEIceChunk",random(-12,12),random(-12,12),random(6,48),random(-2,2),random(-2,2),random(-2,2),0,SXF_NOCHECKPOSITION) // 5 ought to be 'nuff
 		Stop
 	}


### PR DESCRIPTION
Ice death redone to reduce spawning shards by whopping 81% -> lag spikes almost completely eliminated.
Also used inheritance where it's due.
