### PR TITLE
6.07 fixes commence

### DIFF
--- a/Decorate/WepClass8.txt
+++ b/Decorate/WepClass8.txt
@@ -8285,7 +8285,7 @@ Actor StakeTrail
 }
 	
 //******************************************************************
-Actor StakeGGren 
+Actor StakeGGren
 {
 	Projectile
 	Radius 8
@@ -8295,7 +8295,7 @@ Actor StakeGGren
 	-NoGravity
 	Gravity 0.5
 	Speed 35
-	BounceType "Doom"
+	+BOUNCEONWALLS +BOUNCEONFLOORS +BOUNCEONCEILINGS +BOUNCEAUTOOFF //+ALLOWBOUNCEONACTORS
 	+CANBOUNCEWATER
 	+EXTREMEDEATH
 	+FORCERADIUSDMG


### PR DESCRIPTION
Fixed Stake Gun grenade passing through ROTT Spinning Blade. Possibly fixed something else by accident. Removed a feature when a grenade bounces off non-bleeding enemies.
